### PR TITLE
#166326578 An Admin API to View All Cars

### DIFF
--- a/dist/controllers/Car.js
+++ b/dist/controllers/Car.js
@@ -15,6 +15,8 @@ var _Car = _interopRequireDefault(require("../models/Car"));
 
 var _Response = _interopRequireDefault(require("../responses/Response"));
 
+var _User = _interopRequireDefault(require("../models/User"));
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } return target; }
@@ -189,17 +191,21 @@ class CarController {
       if (error) {
         (0, _Response.default)(res, 400, error);
       } else {
-        /* Should only be for admins.
-        Later implement logic to only allows
-        admins to retreive the data */
         const cars = _Car.default.findAllAvailable();
 
         (0, _Response.default)(res, 200, cars);
       }
     } else {
-      const cars = _Car.default.findAll();
+      // Only admins can view this
+      const isAdmin = _User.default.isAdmin(req.user.id);
 
-      (0, _Response.default)(res, 200, cars);
+      if (isAdmin) {
+        const cars = _Car.default.findAll();
+
+        (0, _Response.default)(res, 200, cars);
+      } else {
+        (0, _Response.default)(res, 401, 'You are not an Admin');
+      }
     }
   }
 

--- a/dist/test/test.js
+++ b/dist/test/test.js
@@ -684,3 +684,47 @@ describe('DELETE /api/v1/car/<:car-id>', () => {
     });
   });
 });
+describe('GET /api/v1/car', () => {
+  describe('When the token(Admin) is present', () => {
+    it('When all parameters are correctly supplied the request is successful', done => {
+      _chai.default.request(_server.default).get('/api/v1/car').set('Cookie', 'jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NCwiZW1haWwiOiJraWxsYmlsbEB0ZXN0LmNvbSIsImlhdCI6MTU1OTE0NDIyMiwiZXhwIjoxNTkwNjgwMjIyfQ.Ck2c3jUUCQez0Lp4WFf1iLDkkTUSuHhtIcgTQ7vMwsA').end((err, res) => {
+        expect(err).to.be.null;
+        expect(res, 'response object status').to.have.status(200);
+        expect(res.body, 'response body').to.be.a('object');
+        expect(res.body, 'response body').to.haveOwnProperty('status');
+        expect(res.body.status, 'status property').to.equal(200);
+        expect(res.body, 'response body').to.haveOwnProperty('data');
+        expect(res.body.data, 'data property').to.be.a('array');
+        done();
+      });
+    });
+  });
+  describe('When there are issues with the token', done => {
+    it('The request shouldnt go through if the id encoded in the token does not have Admin privileges', done => {
+      // Jwt missing in cookie
+      _chai.default.request(_server.default).get('/api/v1/car').set('Cookie', 'jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MiwiZW1haWwiOiJ0ZXN0QHRlc3Rlci5jb20iLCJpYXQiOjE1NTg2MDIxMDgsImV4cCI6MTU5MDEzODEwOH0.SgG1OgwgrjF76K9U6edowCEpS5HFJP2hy_06DvwV3jg').end((err, res) => {
+        expect(err).to.be.null;
+        expect(res).to.have.status(401);
+        expect(res.body, 'response body').to.be.a('object');
+        expect(res.body, 'response body').to.haveOwnProperty('status');
+        expect(res.body.status, 'status property').to.equal(401);
+        expect(res.body, 'response body').to.haveOwnProperty('error');
+        expect(res.body.error).to.be.a('string');
+        done();
+      });
+    });
+    it('The request shouldnt go through if the token in the cookie is missing', done => {
+      // Jwt missing in cookie
+      _chai.default.request(_server.default).get('/api/v1/car').end((err, res) => {
+        expect(err).to.be.null;
+        expect(res).to.have.status(401);
+        expect(res.body, 'response body').to.be.a('object');
+        expect(res.body, 'response body').to.haveOwnProperty('status');
+        expect(res.body.status, 'status property').to.equal(401);
+        expect(res.body, 'response body').to.haveOwnProperty('error');
+        expect(res.body.error).to.be.a('string');
+        done();
+      });
+    });
+  });
+});

--- a/src/controllers/Car.js
+++ b/src/controllers/Car.js
@@ -5,6 +5,8 @@ import CarModel from '../models/Car';
 
 import response from '../responses/Response';
 
+import UserModel from '../models/User';
+
 class CarController {
   static createCar(req, res) {
     const {
@@ -131,15 +133,18 @@ class CarController {
       if (error) {
         response(res, 400, error);
       } else {
-        /* Should only be for admins.
-        Later implement logic to only allows
-        admins to retreive the data */
         const cars = CarModel.findAllAvailable();
         response(res, 200, cars);
       }
     } else {
-      const cars = CarModel.findAll();
-      response(res, 200, cars);
+      // Only admins can view this
+      const isAdmin = UserModel.isAdmin(req.user.id);
+      if (isAdmin) {
+        const cars = CarModel.findAll();
+        response(res, 200, cars);
+      } else {
+        response(res, 401, 'You are not an Admin');
+      }
     }
   }
 

--- a/src/test/test.js
+++ b/src/test/test.js
@@ -891,3 +891,58 @@ describe('DELETE /api/v1/car/<:car-id>', () => {
     });
   });
 });
+
+describe('GET /api/v1/car', () => {
+  describe('When the token(Admin) is present', () => {
+    it('When all parameters are correctly supplied the request is successful', (done) => {
+      chai.request(server)
+        .get('/api/v1/car')
+        .set('Cookie', 'jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NCwiZW1haWwiOiJraWxsYmlsbEB0ZXN0LmNvbSIsImlhdCI6MTU1OTE0NDIyMiwiZXhwIjoxNTkwNjgwMjIyfQ.Ck2c3jUUCQez0Lp4WFf1iLDkkTUSuHhtIcgTQ7vMwsA')
+        .end((err, res) => {
+          expect(err).to.be.null;
+          expect(res, 'response object status').to.have.status(200);
+          expect(res.body, 'response body').to.be.a('object');
+          expect(res.body, 'response body').to.haveOwnProperty('status');
+          expect(res.body.status, 'status property').to.equal(200);
+          expect(res.body, 'response body').to.haveOwnProperty('data');
+          expect(res.body.data, 'data property').to.be.a('array');
+          done();
+        });
+    });
+  });
+
+  describe('When there are issues with the token', (done) => {
+    it('The request shouldnt go through if the id encoded in the token does not have Admin privileges', (done) => {
+      // Jwt missing in cookie
+      chai.request(server)
+        .get('/api/v1/car')
+        .set('Cookie', 'jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MiwiZW1haWwiOiJ0ZXN0QHRlc3Rlci5jb20iLCJpYXQiOjE1NTg2MDIxMDgsImV4cCI6MTU5MDEzODEwOH0.SgG1OgwgrjF76K9U6edowCEpS5HFJP2hy_06DvwV3jg')
+        .end((err, res) => {
+          expect(err).to.be.null;
+          expect(res).to.have.status(401);
+          expect(res.body, 'response body').to.be.a('object');
+          expect(res.body, 'response body').to.haveOwnProperty('status');
+          expect(res.body.status, 'status property').to.equal(401);
+          expect(res.body, 'response body').to.haveOwnProperty('error');
+          expect(res.body.error).to.be.a('string');
+          done();
+        });
+    });
+
+    it('The request shouldnt go through if the token in the cookie is missing', (done) => {
+      // Jwt missing in cookie
+      chai.request(server)
+        .get('/api/v1/car')
+        .end((err, res) => {
+          expect(err).to.be.null;
+          expect(res).to.have.status(401);
+          expect(res.body, 'response body').to.be.a('object');
+          expect(res.body, 'response body').to.haveOwnProperty('status');
+          expect(res.body.status, 'status property').to.equal(401);
+          expect(res.body, 'response body').to.haveOwnProperty('error');
+          expect(res.body.error).to.be.a('string');
+          done();
+        });
+    });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
- Implements and API to allow only admins to view all car Ad, sold or unsold

#### Description of Task to be completed?
- Write unit tests
- Implement controller, model and route logic
- Test using Postman

#### How should this be manually tested?
- Clone the repo
- CD into the folder
- Run the command 'npm install'
- Run the command 'npm start'
- Open Postman test the endpoints 'localhost:5000/api/v1/car'

#### What are the relevant pivotal tracker stories?
- #166326578